### PR TITLE
Fix bug of 'scripts/download_dataset.py'

### DIFF
--- a/scripts/download_dataset.py
+++ b/scripts/download_dataset.py
@@ -33,6 +33,7 @@ def main():
                 save_path = os.path.join(save_dir, link[0])
                 if not os.path.exists(save_path):
                     bar = MyProgressBar('Downloading %s' % link[0])
+                    os.makedirs(save_dir, exist_ok=True)
                     wget.download(link[1], save_dir, bar=bar.get_bar)
                     print('\n')
                 print('Unzipping file')
@@ -42,6 +43,7 @@ def main():
             save_path = os.path.join(save_dir, link[0])
             if not os.path.exists(save_path):
                 bar = MyProgressBar('Downloading %s' % link[0])
+                os.makedirs(save_dir, exist_ok=True)
                 wget.download(link[1], save_dir, bar=bar.get_bar)
                 print('\n')
             print('Unzipping file')


### PR DESCRIPTION
Hi, thank you for your work.
When I tried to download dataset using 'scripts/download_dataset.py', some error was occurred.
As I read the code, the code download dataset and unzip in some directory, the bug can be occurred when the directory doesn't exist.
So I add some line that make directory before download the data.

Thank you.